### PR TITLE
chore: promote nodey546 to version 1.0.18

### DIFF
--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-1.0.18-release.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-1.0.18-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-23T10:21:39Z"
+  creationTimestamp: "2021-03-23T11:45:42Z"
   deletionTimestamp: null
-  name: 'nodey546-1.0.16'
+  name: 'nodey546-1.0.18'
   namespace: jx-jx-demo-gke2-prod
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.16
-      sha: aef6c3cef74fb9eae98cd893e25dbd5a32134ab0
+        chore: release 1.0.18
+      sha: 363cc751620ab294701e036dbe88fa441e48b429
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: fdba2cd4ef212746a88d7ebb32bbed3b628a25c4
+      sha: 265e4970cf1c2904f7e8bce135bddec9f9680799
   gitHttpUrl: https://github.com/jstrachan/nodey546
   gitOwner: jstrachan
   gitRepository: nodey546
   name: 'nodey546'
-  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.16
-  version: v1.0.16
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.18
+  version: v1.0.18
 status: {}

--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-nodey546-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey546-nodey546
   labels:
     draft: draft-app
-    chart: "nodey546-1.0.16"
+    chart: "nodey546-1.0.18"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-jx-demo-gke2-prod
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey546-nodey546
       containers:
         - name: nodey546
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.16"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.18"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.16
+              value: 1.0.18
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey546
   labels:
-    chart: "nodey546-1.0.16"
+    chart: "nodey546-1.0.18"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-jx-demo-gke2-prod/helmfile.yaml
+++ b/helmfiles/jx-jx-demo-gke2-prod/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey546
-  version: 1.0.16
+  version: 1.0.18
   name: nodey546
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.18

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
