### PR TITLE
chore: promote nodey546 to version 1.0.30

### DIFF
--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-1.0.30-release.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-1.0.30-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-23T17:29:56Z"
+  creationTimestamp: "2021-03-23T17:42:30Z"
   deletionTimestamp: null
-  name: 'nodey546-1.0.29'
+  name: 'nodey546-1.0.30'
   namespace: jx-jx-demo-gke2-prod
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.29
-      sha: 93262f440eb1c66d6b1f25ed3bec68da2dcb19c5
+        chore: release 1.0.30
+      sha: ea2ba6aa237cf5042e8d9c53c237301906ea86f7
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: c8c179d2958ed4beb4a82986390d840d29e0152b
+      sha: 0a205ffbdb8ad025f540030923b47387148b6d38
   gitHttpUrl: https://github.com/jstrachan/nodey546
   gitOwner: jstrachan
   gitRepository: nodey546
   name: 'nodey546'
-  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.29
-  version: v1.0.29
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.30
+  version: v1.0.30
 status: {}

--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-nodey546-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey546-nodey546
   labels:
     draft: draft-app
-    chart: "nodey546-1.0.29"
+    chart: "nodey546-1.0.30"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-jx-demo-gke2-prod
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey546-nodey546
       containers:
         - name: nodey546
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.29"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.30"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.29
+              value: 1.0.30
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey546
   labels:
-    chart: "nodey546-1.0.29"
+    chart: "nodey546-1.0.30"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-jx-demo-gke2-prod/helmfile.yaml
+++ b/helmfiles/jx-jx-demo-gke2-prod/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey546
-  version: 1.0.29
+  version: 1.0.30
   name: nodey546
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.30

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
