### PR TITLE
chore: promote nodey546 to version 1.0.31

### DIFF
--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-1.0.31-release.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-1.0.31-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-23T17:42:30Z"
+  creationTimestamp: "2021-03-25T08:49:35Z"
   deletionTimestamp: null
-  name: 'nodey546-1.0.30'
+  name: 'nodey546-1.0.31'
   namespace: jx-jx-demo-gke2-prod
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 1.0.30
-      sha: ea2ba6aa237cf5042e8d9c53c237301906ea86f7
+        chore: release 1.0.31
+      sha: 53d093d93c02a8353e5e2dde6afd6761d1299360
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,20 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 0a205ffbdb8ad025f540030923b47387148b6d38
+      sha: 2c567fd41df297b8b11123e5f637c631497ec2d1
+    - author:
+        email: james.strachan@gmail.com
+        name: James Strachan
+      branch: master
+      committer:
+        email: noreply@github.com
+        name: GitHub
+      message: Update index.html
+      sha: 4f67dacc1b453ca4e357377187f5fed3679e06b1
   gitHttpUrl: https://github.com/jstrachan/nodey546
   gitOwner: jstrachan
   gitRepository: nodey546
   name: 'nodey546'
-  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.30
-  version: v1.0.30
+  releaseNotesURL: https://github.com/jstrachan/nodey546/releases/tag/v1.0.31
+  version: v1.0.31
 status: {}

--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-nodey546-deploy.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-nodey546-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey546-nodey546
   labels:
     draft: draft-app
-    chart: "nodey546-1.0.30"
+    chart: "nodey546-1.0.31"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-jx-demo-gke2-prod
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey546-nodey546
       containers:
         - name: nodey546
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.30"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey546:1.0.31"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 1.0.30
+              value: 1.0.31
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-svc.yaml
+++ b/config-root/namespaces/jx-jx-demo-gke2-prod/nodey546/nodey546-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey546
   labels:
-    chart: "nodey546-1.0.30"
+    chart: "nodey546-1.0.31"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-jx-demo-gke2-prod/helmfile.yaml
+++ b/helmfiles/jx-jx-demo-gke2-prod/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/nodey546
-  version: 1.0.30
+  version: 1.0.31
   name: nodey546
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey546 to version 1.0.31

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
