### PR TITLE
chore: promote nodey560 to version 0.0.12

### DIFF
--- a/config-root/cluster/namespaces/myapps.yaml
+++ b/config-root/cluster/namespaces/myapps.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  labels:
+    name: myapps
+    gitops.jenkins-x.io/pipeline: 'cluster'
+    team: 'jx'
+  name: myapps
+spec: {}
+status: {}

--- a/config-root/namespaces/myapps/nodey560/nodey560-ingress.yaml
+++ b/config-root/namespaces/myapps/nodey560/nodey560-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: nodey560/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nodey560
+  namespace: myapps
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: nodey560
+              servicePort: 80
+      host: nodey560-myapps.35.192.63.127.nip.io

--- a/config-root/namespaces/myapps/nodey560/nodey560-nodey560-deploy.yaml
+++ b/config-root/namespaces/myapps/nodey560/nodey560-nodey560-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: nodey560/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodey560-nodey560
+  labels:
+    draft: draft-app
+    chart: "nodey560-0.0.12"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: myapps
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: nodey560-nodey560
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: nodey560-nodey560
+    spec:
+      serviceAccountName: nodey560-nodey560
+      containers:
+        - name: nodey560
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.12"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.12
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/myapps/nodey560/nodey560-nodey560-sa.yaml
+++ b/config-root/namespaces/myapps/nodey560/nodey560-nodey560-sa.yaml
@@ -1,0 +1,8 @@
+# Source: nodey560/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nodey560-nodey560
+  namespace: myapps
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/myapps/nodey560/nodey560-svc.yaml
+++ b/config-root/namespaces/myapps/nodey560/nodey560-svc.yaml
@@ -1,0 +1,18 @@
+# Source: nodey560/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodey560
+  labels:
+    chart: "nodey560-0.0.12"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: myapps
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: nodey560-nodey560

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -7,5 +7,11 @@ namespace: myapps
 repositories:
 - name: dev
   url: http://chartmuseum-jx.34.89.8.12.nip.io
+- name: dev2
+  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
+releases:
+- chart: dev2/nodey560
+  version: 0.0.12
+  name: nodey560
 templates: {}
 renderedvalues: {}

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -13,5 +13,7 @@ releases:
 - chart: dev2/nodey560
   version: 0.0.12
   name: nodey560
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -7,10 +7,8 @@ namespace: myapps
 repositories:
 - name: dev
   url: http://chartmuseum-jx.34.89.8.12.nip.io
-- name: dev2
-  url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
-- chart: dev2/nodey560
+- chart: dev/nodey560
   version: 0.0.12
   name: nodey560
   values:


### PR DESCRIPTION
chore: promote nodey560 to version 0.0.12

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
