### PR TITLE
chore: promote nodey560 to version 0.0.44

### DIFF
--- a/config-root/namespaces/myapps/nodey560/nodey560-nodey560-deploy.yaml
+++ b/config-root/namespaces/myapps/nodey560/nodey560-nodey560-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nodey560-nodey560
   labels:
     draft: draft-app
-    chart: "nodey560-0.0.16"
+    chart: "nodey560-0.0.44"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: myapps
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: nodey560-nodey560
       containers:
         - name: nodey560
-          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.16"
+          image: "gcr.io/jenkins-x-labs-bdd1/nodey560:0.0.44"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.16
+              value: 0.0.44
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/myapps/nodey560/nodey560-svc.yaml
+++ b/config-root/namespaces/myapps/nodey560/nodey560-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: nodey560
   labels:
-    chart: "nodey560-0.0.16"
+    chart: "nodey560-0.0.44"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: myapps
 spec:

--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.89.8.12.nip.io/
 releases:
 - chart: dev/nodey560
-  version: 0.0.16
+  version: 0.0.44
   name: nodey560
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey560 to version 0.0.44

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
