### PR TITLE
chore: promote nodey560 to version 1.0.5

### DIFF
--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://chartmuseum-jx.34.89.8.12.nip.io/
 releases:
 - chart: dev/nodey560
-  version: 0.0.16
+  version: 1.0.5
   name: nodey560
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote nodey560 to version 1.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
