### PR TITLE
chore: promote nodey554 to version 1.0.33

### DIFF
--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: nodey560
   values:
   - jx-values.yaml
+- chart: dev/nodey554
+  version: 1.0.33
+  name: nodey554
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.33

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
