### PR TITLE
chore: promote nodey554 to version 1.0.40

### DIFF
--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -7,11 +7,16 @@ namespace: myapps
 repositories:
 - name: dev
   url: http://chartmuseum-jx.34.89.8.12.nip.io/
+- name: dev2
+  url: http://chartmuseum-jx.35.242.181.72.nip.io/
 releases:
 - chart: dev/nodey560
   version: 0.0.16
   name: nodey560
   values:
   - jx-values.yaml
+- chart: dev2/nodey554
+  version: 1.0.40
+  name: nodey554
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote nodey554 to version 1.0.40

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
