### PR TITLE
chore: promote node-example to version 0.0.1

### DIFF
--- a/helmfiles/myapps/helmfile.yaml
+++ b/helmfiles/myapps/helmfile.yaml
@@ -7,11 +7,16 @@ namespace: myapps
 repositories:
 - name: dev
   url: http://chartmuseum-jx.34.89.8.12.nip.io/
+- name: dev2
+  url: http://chartmuseum-jx.35.242.181.72.nip.io/
 releases:
 - chart: dev/nodey560
   version: 0.0.16
   name: nodey560
   values:
   - jx-values.yaml
+- chart: dev2/node-example
+  version: 0.0.1
+  name: node-example
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote node-example to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
